### PR TITLE
fix(config): Use correct rule name in preset configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,37 +10,32 @@ $ yarn add -D eslint
 $ npm i --save-dev eslint
 ```
 
-Make sure you have `@hulu/eslint-parser-brightscript` installed:
-```
-$ yarn add -D @hulu/eslint-parser-brightscript
-$ npm i --save-dev @hulu/eslint-parser-brightscript
-```
-
-Then install the plugin:
+Then install the parser and plugin:
 
 ```
-$ yarn add -D @hulu/eslint-plugin-brightscript
-$ npm i --save-dev @hulu/eslint-plugin-brightscript
+$ yarn add -D @hulu/eslint-parser-brightscript @hulu/eslint-plugin-brightscript
+$ npm i --save-dev @hulu/eslint-parser-brightscript @hulu/eslint-plugin-brightscript
 ```
 
 ### Usage
 Add the following to your .eslintrc to use the recommended rules.
-```
+
+```json
 {
     "plugins": ["@hulu/eslint-plugin-brightscript"],
     "extends": ["plugin:@hulu/eslint-plugin-brightscript/recommended"]
 }
 ```
 
-You can also ignore the recommended config by including the `@hulu/eslint-parser-brightscript`
-and adding specific rules manually.
+You can also ignore the recommended config by including the `@hulu/eslint-parser-brightscript` parser and
+`@hulu/eslint-plugin-brightscript` plugin and adding specific rules manually:
 
-```
+```json
 {
   "parser": "@hulu/eslint-parser-brightscript",
   "plugins": ["@hulu/eslint-plugin-brightscript"],
   "rules": {
-    "@hulu/eslint-plugin-brightscript/rule-name": "error"
+    "@hulu/brightscript/rule-name": "error"
   }
 }
 ```

--- a/packages/eslint-plugin/src/configs/recommended-hulu.ts
+++ b/packages/eslint-plugin/src/configs/recommended-hulu.ts
@@ -1,10 +1,10 @@
 export = {
     extends: ["./configs/base"],
     rules: {
-        "@hulu/eslint-plugin-brightscript/no-set-focus-false": "error",
-        "@hulu/eslint-plugin-brightscript/no-is-valid": "error",
-        "@hulu/eslint-plugin-brightscript/onkeyevent-boolean-return-type": "error",
-        "@hulu/eslint-plugin-brightscript/no-unsafe-conditions": "error",
-        "@hulu/eslint-plugin-brightscript/no-typed-func-params": "warn",
+        "@hulu/brightscript/no-set-focus-false": "error",
+        "@hulu/brightscript/no-is-valid": "error",
+        "@hulu/brightscript/onkeyevent-boolean-return-type": "error",
+        "@hulu/brightscript/no-unsafe-conditions": "error",
+        "@hulu/brightscript/no-typed-func-params": "warn",
     },
 };

--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -1,6 +1,6 @@
 export = {
     extends: ["./configs/base"],
     rules: {
-        "@hulu/eslint-plugin-brightscript/no-set-focus-false": "error",
+        "@hulu/brightscript/no-set-focus-false": "error",
     },
 };


### PR DESCRIPTION
The ESLint documentation isn't terribly clear on how to reference rules from a scoped package named `@scope/eslint-plugin-<plugin-name>`, so a last-minute rename before public release switched to some definitely-incorrect values.  Use `@hulu/brightscript/<rule-name>` to reference rules from this plugin.